### PR TITLE
Create the logs directory

### DIFF
--- a/docker/rocm-silogen-finetuning-worker.Dockerfile
+++ b/docker/rocm-silogen-finetuning-worker.Dockerfile
@@ -6,3 +6,4 @@ RUN pip install --no-cache-dir --extra-index-url https://download.pytorch.org/wh
 RUN pip install --no-cache-dir --extra-index-url https://download.pytorch.org/whl/rocm6.2 /finetuning
 
 WORKDIR /workdir
+RUN mkdir /workdir/logs


### PR DESCRIPTION
This directory stores Tensorboard logs (or potentially later some similar ones). Everything works, but since it's only created when the first logs hit, the mc mirror operation that's used in https://github.com/silogen/ai-workloads-dev outputs a lot of complaints about not finding the directory at the start of the job.