### PR TITLE
Update config doc generation to avoid manual fixing

### DIFF
--- a/scripts/generate_markdown_config_doc.py
+++ b/scripts/generate_markdown_config_doc.py
@@ -5,21 +5,31 @@ import finetuning
 # This script generates a markdown document from the pydantic model of the finetuning config,
 # by converting it to a json schema and then to markdown.
 
-# The output is used as the basis for the silogen-finetuning-engine documentation in the silogen/ai-workloads repository.
-# Some manual editing is done to make it more readable before publishing:
-#  - add additional descriptions
-#  - fix bad formatting
+# The output is used for the silogen-finetuning-engine documentation in the silogen/ai-workloads repository.
 
 # NB: some of the naming in the output uses JSON conventions, which might be misleading.
 # E.g., "number" and "null" rather than "float" and "None". This should perhaps be modified.
-# Also a default value of False for a boolean parameter shows up as empty in the markdown.
 
 schema = finetuning.config.SFTExperimentConfig.model_json_schema()
 markdown = jsonschema_markdown.generate(schema, hide_empty_columns=True, footer=False)
 
+# Replace the introduction with a custom one
+intro = """# Finetuning config structure and parameters
+
+This document describes the structure of the finetuning configuration, and the parameters and values that can be defined there.
+
+See the finetuning config section [this config file](overrides/llama-31-tiny-random-deepspeed-values.yaml) for an example of a valid configuration.
+See the various sub-configs for their options. Additional properties are not allowed.
+
+**Top-level properties:**
+
+"""
+markdown = (
+    intro + markdown[markdown.index("| Property | Type | Required | Possible values | Default | Description |") :]
+)
+
 # Remove parts related to HuggingFace TrainingArguments and its sub-classes
 to_remove = [
-    "ChatTemplateName",
     "DebugOption",
     "FSDPOption",
     "HubStrategy",
@@ -27,13 +37,29 @@ to_remove = [
     "OptimizerNames",
     "SaveStrategy",
     "SchedulerType",
-    "SilogenTrainingArguments",
 ]
+# Custom section to use for SilogenTrainingArguments
+silogen_training_args_section = """SilogenTrainingArguments
+
+HuggingFace TrainingArguments as Config with additional SiloGen conventions
+
+The list of training arguments is best available online (the version might not be up-to-date here):
+https://huggingface.co/docs/transformers/main/en/main_classes/trainer#transformers.TrainingArguments
+
+The TrainingArguments object does a lot of things besides specifying the training configuaration options (e.g. it
+has computed properties like true training batch size etc.)
+"""
 sections = markdown.split("\n## ")
+sections = [
+    silogen_training_args_section if section.startswith("SilogenTrainingArguments") else section for section in sections
+]
 markdown = "\n## ".join(section for section in sections if section.split(maxsplit=1)[0] not in to_remove)
 
 # Remove the repeated "Additional properties are not allowed" mentions
 markdown = markdown.replace("> ⚠️ Additional properties are not allowed.\n\n", "")
+
+# Make sure default "False" is shown for boolean parameters
+markdown = markdown.replace("`boolean` |  | boolean |  |", "`boolean` |  | boolean | `False` |")
 
 with open("ft_config_doc.md", "w") as f:
     f.write(markdown)

--- a/src/finetuning/config/data.py
+++ b/src/finetuning/config/data.py
@@ -7,6 +7,8 @@ from finetuning.config.base import BaseConfig
 
 
 class ChatTemplateName(str, Enum):
+    """Chat template to use."""
+
     MISTRAL_WITH_SYSTEM = "mistral-with-system"
     CHAT_ML = "chat-ml"
     PORO = "poro"
@@ -52,8 +54,10 @@ class DataInput(BaseConfig):
     """Base config for data input"""
 
     type: DataInputType
-    # Note: generally, the data_type is automatically set based on the experiment config method
-    data_type: str = "ChatConversation"  # type: ignore
+    data_type: str = Field(
+        default="ChatConversation",
+        description="Generally, the data_type is automatically set based on the experiment config method.",
+    )
 
 
 class ConcatenationDataInput(DataInput):
@@ -63,9 +67,12 @@ class ConcatenationDataInput(DataInput):
 
     The datasets themselves need to be in the finetuning supported JSONL formats.
     For SFT this means lines:
-    {"messages": {"content": "string", "role": "string"}}
+
+        {"messages": {"content": "string", "role": "string"}}
+
     For DPO this means lines of:
-    {"prompt_messages": {"content": "string", "role": "string"}, "chosen_messages": {"content": "string", "role": "string"}, "rejected_messages": {"content": "string", "role": "string"}}
+
+        {"prompt_messages": {"content": "string", "role": "string"}, "chosen_messages": {"content": "string", "role": "string"}, "rejected_messages": {"content": "string", "role": "string"}}
     """
 
     type: Literal[DataInputType.CONCATENATION]
@@ -81,9 +88,12 @@ class WeightedMixDataInput(DataInput):
 
     The datasets themselves need to be in the finetuning supported JSONL formats.
     For SFT this means lines:
-    {"messages": {"content": "string", "role": "string"}}
+
+        {"messages": {"content": "string", "role": "string"}}
+
     For DPO this means lines of:
-    {"prompt_messages": {"content": "string", "role": "string"}, "chosen_messages": {"content": "string", "role": "string"}, "rejected_messages": {"content": "string", "role": "string"}}
+
+        {"prompt_messages": {"content": "string", "role": "string"}, "chosen_messages": {"content": "string", "role": "string"}, "rejected_messages": {"content": "string", "role": "string"}}
     """
 
     type: Literal[DataInputType.PRECOMPUTE_WEIGHTED_MIX]

--- a/src/finetuning/config/experiment.py
+++ b/src/finetuning/config/experiment.py
@@ -31,8 +31,7 @@ logger = logging.get_logger(__file__)
 class FinetuningTrackingConfig(TrackingConfig):
     """Settings that define how run details are logged"""
 
-    hf_mlflow_log_artifacts: str = "False"
-    "Whether to store model artifacts in MLFlow"
+    hf_mlflow_log_artifacts: str = Field(default="False", description="Whether to store model artifacts in MLFlow.")
 
 
 class Overrides(BaseConfig):
@@ -47,9 +46,9 @@ class Overrides(BaseConfig):
     lr_batch_size_scaling: Literal["none", "sqrt", "linear"] = Field(
         default="none",
         description=dedent(
-            """Scales the learning rate in the training_args by a factor derived from the total training batch size.
-            'none': No scaling.
-            'sqrt': Multiplies learning rate by square root of batch size (a classic scaling rule).
+            """Scales the learning rate in the training_args by a factor derived from the total training batch size. \
+            'none': No scaling. \
+            'sqrt': Multiplies learning rate by square root of batch size (a classic scaling rule). \
             'linear': Multiplies learning rate by the batch size (a more modern scaling rule).
             """
         ),

--- a/src/finetuning/config/hf_integration.py
+++ b/src/finetuning/config/hf_integration.py
@@ -225,7 +225,7 @@ class PretrainedPeftConfig(BaseConfig):
     """PEFT adapter uses the config and initialisation from a pretrained adapter"""
 
     peft_type: Literal[PRETRAINED_PEFT]  # type: ignore
-    name_or_path: str  # HF ID or path to the pretrained peft
+    name_or_path: str = Field(description="HF ID or path to the pretrained peft.")
 
 
 class GenericPeftConfig(BaseConfig):
@@ -234,8 +234,8 @@ class GenericPeftConfig(BaseConfig):
     See https://huggingface.co/docs/peft/tutorial/peft_model_config for the possible kwargs
     and https://github.com/huggingface/peft/blob/v0.7.1/src/peft/utils/peft_types.py for the types.
 
-    Example
-    =======
+    Example:
+
         >>> loaded_data = {'peft_type':'LORA', 'task_type': 'CAUSAL_LM',
         ...         'peft_kwargs': {'r': 32, 'target_modules': ['v_proj']}}
         >>> generic_conf = GenericPeftConfig(**loaded_data)
@@ -263,6 +263,8 @@ class GenericPeftConfig(BaseConfig):
 
 
 class SFTArguments(BaseConfig):
+    """Supervised fine-tuning arguments"""
+
     max_seq_length: int = Field(
         default=2048, description="Maximum length input sequence length. Longer sequences will be filtered out."
     )
@@ -272,4 +274,4 @@ class SFTArguments(BaseConfig):
     save_name_if_new_basemodel: str = Field(
         default="checkpoint-new-basemodel", description="If a new basemodel is saved, it will be saved with this name"
     )
-    train_on_completions_only: bool = Field(default=False, description="Only comput loss on the assistant's turns.")
+    train_on_completions_only: bool = Field(default=False, description="Only compute loss on the assistant's turns.")

--- a/src/finetuning/config/run.py
+++ b/src/finetuning/config/run.py
@@ -15,17 +15,17 @@ class ModelArguments(BaseConfig):
     https://huggingface.co/docs/transformers/main/en/main_classes/model#transformers.PreTrainedModel.from_pretrained
     See below in "Parameters for big model inference" too, it affects training too. Also note that this link takes you
     to the transformers main branch version - be sure to compare with the installed version of transformers (that keeps
-    changing over time, and it is difficult to keep this doctstring up to date, so we wanted to link to the latest here).
+    changing over time, and it is difficult to keep this docstring up to date, so we wanted to link to the latest here).
 
     Some important parameters to consider are:
 
-    device_map :
+    - device_map :
         A map that specifies where each submodule should go. It doesn’t need to be refined to each parameter/buffer
         name, once a given module name is inside, every submodule of it will be sent to the same device. If we only pass
         the device (e.g., "cpu", "cuda:1", "mps", or a GPU ordinal rank like 1) on which the model will be allocated,
         the device map will map the entire model to this device. Passing device_map = 0 means put the whole model on GPU
         0.
-    attn_implementation :
+    - attn_implementation :
         The attention implementation to use in the model (if relevant). Can be any of "eager" (manual implementation of
         the attention), "sdpa" (using F.scaled_dot_product_attention), or "flash_attention_2" (using
         Dao-AILab/flash-attention). By default, if available, SDPA will be used for torch>=2.1.1. The default is
@@ -58,21 +58,27 @@ class ModelArguments(BaseConfig):
         else:
             return str(x)[len("torch.") :]  # Remove the "torch." prefix
 
-    # Custom device map so that you can manually override the choices that HuggingFace would make.
-    # This can also be a string to specify "auto", "balanced_low_0", or "sequential"
-    device_map: Dict[str, int | str] | str | None = None
+    device_map: Dict[str, int | str] | str | None = Field(
+        default=None,
+        description='Custom device map so that you can manually override the choices that HuggingFace would make. This can also be a string to specify "auto", "balanced_low_0", or "sequential".',
+    )
     max_memory: Optional[Dict[str, str]] = None
     low_cpu_mem_usage: bool = False
-    # Note: this can be set to "sdpa", "flash_attention_2", "eager"
-    attn_implementation: Optional[str] = None
+    attn_implementation: Optional[str] = Field(
+        default=None,
+        description='Note: this can be set to "sdpa", "flash_attention_2", "eager".',
+    )
     offload_folder: Optional[str] = None
-    offload_state_dict: Optional[bool] = None  # Default is True if offloading (otherwise no effect)
+    offload_state_dict: Optional[bool] = Field(
+        default=None,
+        description="Default is True if offloading (otherwise no effect)",
+    )
     offload_buffers: Optional[bool] = None
 
-    # Saves generated hidden states to speed up generation
-    # see: https://discuss.huggingface.co/t/what-is-the-purpose-of-use-cache-in-decoder/958
-    # use_cache is mutually exclusive with gradient_checkpointing
-    use_cache: bool = True
+    use_cache: bool = Field(
+        default=True,
+        description="Saves generated hidden states to speed up generation, see: https://discuss.huggingface.co/t/what-is-the-purpose-of-use-cache-in-decoder/958 This is mutually exclusive with gradient_checkpointing.",
+    )
 
     # HF HUB arguments:
     cache_dir: Optional[str] = None
@@ -86,8 +92,10 @@ class ModelArguments(BaseConfig):
     token: Optional[str] = None
     use_safetensors: Optional[bool] = None
     variant: Optional[str] = None
-    # Warning: if set to True, allows execution of downloaded remote code
-    trust_remote_code: bool = False
+    trust_remote_code: bool = Field(
+        default=False,
+        description="Warning: if set to True, allows execution of downloaded remote code.",
+    )
 
     def model_post_init(self, __context):
         accelerate_state = PartialState()
@@ -126,7 +134,7 @@ class RunConfig(BaseConfig):
         default=False,
         description=dedent(
             """\
-        Normally should be set to 'auto' to continue if a checkpoint exists.
+        Normally should be set to 'auto' to continue if a checkpoint exists.\
         Can set to True to always try to continue, False to never try, or a path to load from a specific path."""
         ),
     )
@@ -137,12 +145,12 @@ class RunConfig(BaseConfig):
         default="no",
         description=dedent(
             """\
-            Set the level of determinism in implementations. Deterministic implementations are not always available,
-            and when they are, they are usually slower than their non-deterministic counterparts. Recommended for
-            debugging only.
-            'no': No determinism.
-            'half': Prefer deterministic implementations.
-            'full': Only fully deterministic implementations, error out on operations that only have non-deterministic
+            Set the level of determinism in implementations. Deterministic implementations are not always available,\
+            and when they are, they are usually slower than their non-deterministic counterparts. Recommended for\
+            debugging only.\
+            'no': No determinism.\
+            'half': Prefer deterministic implementations.\
+            'full': Only fully deterministic implementations, error out on operations that only have non-deterministic\
                     implementations."""
         ),
     )

--- a/src/finetuning/config/tracking.py
+++ b/src/finetuning/config/tracking.py
@@ -1,14 +1,17 @@
+from typing import Optional
+
+from pydantic import Field
+
 from finetuning.config.base import BaseConfig
 
 
 class TrackingConfig(BaseConfig):
     """Config for tracking experiment results in MLFlow"""
 
-    mlflow_server_uri: str
-    "MLflow server URI. Can be local path."
-    experiment_name: str
-    "Experiment name that is used for MLFlow tracking"
-    run_id: str | None = None
-    "Run id, to resume logging to previousely started run"
-    run_name: str | None = None
-    "Run name, to give meaningful name to the run to be displayed in MLFlow UI. Used only when run_id is unspecified."
+    mlflow_server_uri: str = Field(description="MLflow server URI. Can be local path.")
+    experiment_name: str = Field(description="Experiment name that is used for MLFlow tracking.")
+    run_id: Optional[str] = Field(default=None, description="Run id, to resume logging to previously started run.")
+    run_name: Optional[str] = Field(
+        default=None,
+        description="Run name, to give meaningful name to the run to be displayed in MLFlow UI. Used only when run_id is unspecified.",
+    )


### PR DESCRIPTION
- Update generate_markdown_config_doc.py to add custom descriptions for SilogenTrainingArguments and the introduction
- Fix invisible boolean default value if "False"
- Rewrite comments in python code as pydantic Field descriptions
- Formatting fixes to render better in markdown