### PR TITLE
ROCM Image supporting radeon 

### DIFF
--- a/docker/rocm-silogen-finetuning-base.Dockerfile
+++ b/docker/rocm-silogen-finetuning-base.Dockerfile
@@ -1,4 +1,4 @@
-FROM rocm/pytorch:rocm7.0.2_ubuntu24.04_py3.12_pytorch_release_2.8.0
+FROM rocm/pytorch:rocm7.2_ubuntu24.04_py3.12_pytorch_release_2.9.1
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/docker/rocm-silogen-finetuning-base.Dockerfile
+++ b/docker/rocm-silogen-finetuning-base.Dockerfile
@@ -1,12 +1,12 @@
-FROM rocm/vllm:rocm7.0.0_vllm_0.11.2_20251210
+FROM rocm/pytorch:rocm7.0.2_ubuntu24.04_py3.12_pytorch_release_2.8.0
 
 ARG DEBIAN_FRONTEND=noninteractive
 
 # This image is designed to be run as non-root user
 ENV USER_NAME=user
-ENV USER_ID=1000
+ENV USER_ID=1001
 ENV GROUP_NAME=silogen
-ENV GROUP_ID=1000
+ENV GROUP_ID=1001
 RUN groupadd -g ${GROUP_ID} ${GROUP_NAME} && \
     useradd -m -g ${GROUP_ID} -u ${USER_ID} ${USER_NAME} \
     && mkdir /workdir \


### PR DESCRIPTION
TODO
- Doesnt have flash-attention installed in the image
    -  For now, use `attn_implementation: sdpa`