### PR TITLE
Optional use cache

### DIFF
--- a/src/finetuning/config/experiment.py
+++ b/src/finetuning/config/experiment.py
@@ -115,7 +115,7 @@ class ExperimentConfig(BaseConfig):
 
     def model_post_init(self, __context):
         self.__apply_overrides()
-        if self.training_args.gradient_checkpointing and self.run_conf.model_args.use_cache:
+        if self.training_args.gradient_checkpointing and self.run_conf.model_args.use_cache is True:
             # These are mutually incompatible
             logger.warning(
                 "Setting run_conf.model_args.use_cache=False, because training_args.gradient_checkpointing=True"

--- a/src/finetuning/config/run.py
+++ b/src/finetuning/config/run.py
@@ -111,7 +111,7 @@ class ModelArguments(BaseConfig):
 
     def get_model_load_kwargs(self):
         """Returns a dictionary that is ready to be passed to AutoModelForCausalLM.from_pretrained as **kwargs"""
-        return self.model_dump(exclude_unset=True)
+        return self.model_dump(exclude_unset=True, exclude_none=True)
 
 
 class RunConfig(BaseConfig):

--- a/src/finetuning/config/run.py
+++ b/src/finetuning/config/run.py
@@ -75,9 +75,9 @@ class ModelArguments(BaseConfig):
     )
     offload_buffers: Optional[bool] = None
 
-    use_cache: bool = Field(
-        default=True,
-        description="Saves generated hidden states to speed up generation, see: https://discuss.huggingface.co/t/what-is-the-purpose-of-use-cache-in-decoder/958 This is mutually exclusive with gradient_checkpointing.",
+    use_cache: Optional[bool] = Field(
+        default=None,
+        description="If set, forwards use_cache to Transformers. Leave as null to use the model default. This is mutually exclusive with gradient_checkpointing when set to true.",
     )
 
     # HF HUB arguments:

--- a/src/finetuning/config/run.py
+++ b/src/finetuning/config/run.py
@@ -77,7 +77,7 @@ class ModelArguments(BaseConfig):
 
     use_cache: Optional[bool] = Field(
         default=None,
-        description="If set, forwards use_cache to Transformers. Leave as null to use the model default. This is mutually exclusive with gradient_checkpointing when set to true.",
+        description="Saves generated hidden states to speed up generation, see: https://discuss.huggingface.co/t/what-is-the-purpose-of-use-cache-in-decoder/958. Default is None (unset). This is mutually exclusive with gradient_checkpointing.",
     )
 
     # HF HUB arguments:


### PR DESCRIPTION
Make use_cache optional 

Also added exclusion of null fields *exclude_none=True*

`def get_model_load_kwargs(self):
        """Returns a dictionary that is ready to be passed to AutoModelForCausalLM.from_pretrained as **kwargs"""
        return self.model_dump(exclude_unset=True, exclude_none=True)`