### PR TITLE
No ssl verify on curl

### DIFF
--- a/docker/rocm-silogen-finetuning-base.Dockerfile
+++ b/docker/rocm-silogen-finetuning-base.Dockerfile
@@ -17,6 +17,7 @@ RUN groupadd -g ${GROUP_ID} ${GROUP_NAME} && \
 RUN curl https://dl.min.io/client/mc/release/linux-amd64/mc \
     --create-dirs \
     --location \
+    --insecure \
     -o /minio-binaries/mc && \
     chown -hR ${USER_NAME} /minio-binaries/ && \
     chmod +x /minio-binaries/mc


### PR DESCRIPTION
With clean builds, we may need to add this to support some build environments.